### PR TITLE
Enable ignoreOwnVisits with ackee

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -50,7 +50,7 @@ const config: GatsbyConfig = {
             : "36fb18bc-3525-49a2-bed9-7bd1fcd372a4", // production
         server: "https://insights.aeroteameindhoven.nl",
         ignoreLocalhost: true,
-        ignoreOwnVisits: false,
+        ignoreOwnVisits: true,
         detailed: true
       }
     },


### PR DESCRIPTION
This will prevent me, and anyone else who has logged in on the insights dashboard from contributing to the analytics so that the analytics are not tainted from us viewing it.