### PR TITLE
Cache the public directory

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -64,7 +64,9 @@ jobs:
       - name: Restore cache
         uses: actions/cache@v3
         with:
-          path: .cache
+          path: |
+            .cache
+            public
           key: ${{ runner.os }}-gatsby-build
           restore-keys: |
             ${{ runner.os }}-gatsby-build


### PR DESCRIPTION
Looking through the docs and the logs, both the `.cache` and `public` directories need to be saved. If one is missing, the whole cache is ignored, hence our large build times. 
```
info We've detected that the Gatsby cache is incomplete (the .cache directory exists
but the public directory does not). As a precaution, we're deleting your site's
cache to ensure there's no stale data.
```

This change should improve future build times.